### PR TITLE
fix(packaging): ship the ghostty terminfo database in the app bundle

### DIFF
--- a/scripts/package_app.sh
+++ b/scripts/package_app.sh
@@ -23,8 +23,8 @@ if [[ ! -f "${BIN_PATH}" ]]; then
   exit 1
 fi
 
-RESOURCES_DIR=$(ls -td target/release/build/ghostty-sys-*/out/ghostty/share/ghostty 2>/dev/null | head -1)
-if [[ -z "${RESOURCES_DIR}" || ! -d "${RESOURCES_DIR}" ]]; then
+SHARE_DIR=$(ls -td target/release/build/ghostty-sys-*/out/ghostty/share 2>/dev/null | head -1)
+if [[ -z "${SHARE_DIR}" || ! -d "${SHARE_DIR}/ghostty" || ! -d "${SHARE_DIR}/terminfo" ]]; then
   echo "error: ghostty resources not found under target/release/build" >&2
   exit 1
 fi
@@ -44,7 +44,12 @@ if [[ -n "${VERSION}" ]]; then
   /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${VERSION}" "${APP_DIR}/Contents/Info.plist"
 fi
 cp "${ICON_PATH}" "${APP_DIR}/Contents/Resources/app-icon.icns"
-cp -R "${RESOURCES_DIR}" "${APP_DIR}/Contents/Resources/ghostty"
+cp -R "${SHARE_DIR}/ghostty" "${APP_DIR}/Contents/Resources/ghostty"
+cp -R "${SHARE_DIR}/terminfo" "${APP_DIR}/Contents/Resources/terminfo"
+if [[ ! -f "${APP_DIR}/Contents/Resources/terminfo/78/xterm-ghostty" ]]; then
+  echo "error: xterm-ghostty terminfo missing from ${APP_DIR}" >&2
+  exit 1
+fi
 
 codesign --force --deep --sign - --identifier "${BUNDLE_ID}" "${APP_DIR}"
 


### PR DESCRIPTION
## Problem

libghostty sets `TERM=xterm-ghostty` and exports `TERMINFO=<bundle>/Contents/Resources/terminfo` (`vendor/ghostty/src/termio/Exec.zig:643-657`, derived from the resources dir Combe passes in `crates/combe/src/main.rs:23-31`). Packaging copied only `share/ghostty`, so that directory never existed in the bundle and `xterm-ghostty` — absent from the macOS system database — resolved nowhere.

Measured in a real Combe surface from the current `/Applications/Combe.app`:

```
TERM=xterm-ghostty
TERMINFO=/Applications/Combe.app/Contents/Resources/terminfo
infocmp=FAIL
```

With no resolvable entry, zsh's line editor loses its erase capability. Each Backspace writes a bare space instead of `BS SP BS`, so the character stays on screen and the cursor advances — the line buffer was right all along, only the display was wrong. Captured from a PTY, typing `echo HELLOWORLD123` then five Backspaces:

```
unresolvable TERMINFO:   "     "                  (5 spaces, nothing erased)
resolvable TERMINFO:     "^H ^H^H ^H^H ^H..."     (erases)
```

## Change

Resolve the build prefix once at `share/`, copy `terminfo` alongside `ghostty` from that same prefix, and assert the `xterm-ghostty` entry actually landed in the bundle. The input guard now also requires `share/terminfo` to exist.

The gap never showed up in development because a non-bundled run resolves the resources dir to the build prefix, whose sibling `share/terminfo` is present. Only the packaged app was broken, so the assertion sits in the packaging script — where `make app` and the release workflow both run it.

## Verification

- `bash scripts/package_app.sh` → `build/Combe.app/Contents/Resources/terminfo/{67/ghostty,78/xterm-ghostty}`
- `TERMINFO=build/Combe.app/Contents/Resources/terminfo infocmp -1 xterm-ghostty` resolves
- `codesign --verify --deep --strict build/Combe.app` passes
- Launched the packaged app and probed a live surface: `infocmp=ok`
- Backspace repro against the bundle's terminfo now emits `^H ^H`
- `make check` passes

## Note on #2

The same defect explains the symptom reported in #2. `IUTF8` is set on the PTY: the shipped v0.2.1 binary contains `openpty → tcgetattr → orr #0x4000 → tcsetattr`, the only `tcsetattr` call site in it, and a live Combe PTY reports `iutf8` (probed above alongside `infocmp=FAIL`). The `-iutf8` measured there comes from the `stty sane` that ends that report's own byte-level test — `stty sane` clears `IUTF8` on macOS. `IUTF8` only governs canonical-mode ERASE, which is not the path a zle prompt takes.

Closes #3